### PR TITLE
chore(deps): update to reference renamed sn_api, sn_cli and sn_ffi

### DIFF
--- a/Build/NativeScriptDownloader.cake
+++ b/Build/NativeScriptDownloader.cake
@@ -1,6 +1,6 @@
 var TAG = "b9dd513";
 
-var S3_DOWNLOAD_BASE_URL = "https://safe-api.s3.amazonaws.com/";
+var S3_DOWNLOAD_BASE_URL = "https://sn_api.s3.amazonaws.com/";
 var LIB_DIR_NAME = "../SafeApp.AppBindings/NativeLibs/";
 var ANDROID_DIR_NAME = $"{LIB_DIR_NAME}Android";
 var IOS_DIR_NAME = $"{LIB_DIR_NAME}iOS";
@@ -61,7 +61,7 @@ Task("Download-Libs")
         foreach (var varient in varients)
         {
           var targetDirectory = $"{Native_DIR.Path}/{item}/{target}";
-          var zipFileName = varient == "" ? $"safe-ffi-{TAG}-{target}.zip" : $"safe-ffi-{TAG}-{target}-{varient}.zip";
+          var zipFileName = varient == "" ? $"sn_ffi-{TAG}-{target}.zip" : $"sn_ffi-{TAG}-{target}-{varient}.zip";
           var zipFileDownloadUrl = $"{S3_DOWNLOAD_BASE_URL}{zipFileName}";
           var zipSavePath = $"{Native_DIR.Path}/{item}/{target}/{zipFileName}";
 
@@ -149,7 +149,7 @@ Task("UnZip-Libs")
           var unZippedFiles = GetFiles($"{platformOutputDirectory.ToString()}/*.*");
           foreach (var file in unZippedFiles)
           {
-            MoveFile(file.FullPath, file.FullPath.Replace("safe_ffi", "safe_api"));
+            MoveFile(file.FullPath, file.FullPath.Replace("sn_ffi", "sn_api"));
           }
         }
       }

--- a/Build/get_release_description.sh
+++ b/Build/get_release_description.sh
@@ -1,5 +1,5 @@
 read -r -d '' release_description << 'EOF'
-NET wrapper package for [safe-api](https://github.com/maidsafe/safe-api/).
+NET wrapper package for [sn_api](https://github.com/maidsafe/sn_api/).
 
 ## Changelog
 CHANGELOG_CONTENT
@@ -11,10 +11,10 @@ NUGET_PACKAGE_CHECKSUM
 ```
 
 ## Related Links
-* SAFE Browser - [Desktop](https://github.com/maidsafe/safe_browser/releases/) | [Mobile](https://github.com/maidsafe/safe-mobile-browser/)
-* [SAFE Mobile Authenticator](https://github.com/maidsafe/safe-authenticator-mobile/)
-* [SAFE CLI](https://github.com/maidsafe/safe-api/tree/master/safe-cli)
-* [SAFE Vault](https://github.com/maidsafe/safe_vault/releases/latest/)
+* Safe Browser - [Desktop](https://github.com/maidsafe/safe_browser/releases/) | [Mobile](https://github.com/maidsafe/safe-mobile-browser/)
+* [Safe Mobile Authenticator](https://github.com/maidsafe/safe-authenticator-mobile/)
+* [Safe CLI](https://github.com/maidsafe/sn_api/tree/master/sn_cli)
+* [Safe Vault](https://github.com/maidsafe/safe_vault/releases/latest/)
 EOF
 
 commitMessage=$(git log --format=%B -n 1)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # safe_app_csharp [![NuGet](https://img.shields.io/nuget/v/MaidSafe.SafeApp.svg)](https://www.nuget.org/packages/MaidSafe.SafeApp)
 
-.NET wrapper package for [safe-api](https://github.com/maidsafe/safe-api/).
+.NET wrapper package for [sn_api](https://github.com/maidsafe/sn_api/).
 
-> [safe_app](https://github.com/maidsafe/safe-api/) is a native library which exposes high level API for application development on SAFE Network. It exposes API for authorisation and to manage data on the network.
+> [sn_api](https://github.com/maidsafe/sn_api/) is a native library which exposes high level API for application development on Safe Network. It exposes API for authorisation and to manage data on the network.
 
 **Maintainer:** Ravinder Jangra (ravinder.jangra@maidsafe.net)
 
@@ -14,30 +14,34 @@
 
 ## Table of Contents
 
-1. [Overview](#Overview)
-2. [Supported Platforms](#Supported-Platforms)
-3. [API Usage](#API-Usage)
-4. [Documentation](#Documentation)
-5. [Development](#Development)
-    * [Project Structure](#Project-structure)
-    * [Platform Invoke](#Interoperability-between-C-managed-and-unmanaged-code)
-    * [Interfacing with SCL](#Interfacing-with-Safe-Client-Libs)
-    * [Tests](#Tests)
-    * [Packaging](#Packaging)
-    * [Tools required](#Tools-required)
-6. [Useful resources](#Useful-resources)
-7. [Copyrights](#Copyrights)
-8. [Further Help](#Further-Help)
-9. [License](#License)
-10. [Contributing](#Contributing)
+- [safe_app_csharp ![NuGet](https://www.nuget.org/packages/MaidSafe.SafeApp)](#safe_app_csharp-img-srchttpsimgshieldsionugetvmaidsafesafeappsvg-altnuget)
+  - [Build Status](#build-status)
+  - [Table of Contents](#table-of-contents)
+  - [Supported Platforms](#supported-platforms)
+  - [API Usage](#api-usage)
+    - [Using Mock API](#using-mock-api)
+    - [Authentication](#authentication)
+  - [Documentation](#documentation)
+  - [Development](#development)
+    - [Project structure](#project-structure)
+    - [Interoperability between C# managed and unmanaged code](#interoperability-between-c-managed-and-unmanaged-code)
+    - [Interfacing with Safe Client Libs](#interfacing-with-safe-client-libs)
+    - [Tests](#tests)
+    - [Packaging](#packaging)
+    - [Tools required](#tools-required)
+  - [Useful resources](#useful-resources)
+  - [Copyrights](#copyrights)
+  - [Further Help](#further-help)
+  - [License](#license)
+  - [Contributing](#contributing)
 
-This project contains the C# bindings and API wrappers for the [safe_app](https://github.com/maidsafe/safe-api/) and mock [safe_authenticator](https://github.com/maidsafe/safe_client_libs/tree/master/safe_authenticator). The native libraries, bindings and API wrapper are built and published as a NuGet package. The latest version can be fetched from the [MaidSafe.SafeApp NuGet package](https://www.nuget.org/packages/MaidSafe.SafeApp/).
+This project contains the C# bindings and API wrappers for the [sn_api](https://github.com/maidsafe/sn_api/) and mock [safe_authenticator](https://github.com/maidsafe/safe_client_libs/tree/master/safe_authenticator). The native libraries, bindings and API wrapper are built and published as a NuGet package. The latest version can be fetched from the [MaidSafe.SafeApp NuGet package](https://www.nuget.org/packages/MaidSafe.SafeApp/).
 
 At a very high level, this package includes:
 
 * C# API for devs for easy app development.
-* safe-api and mock safe_authenticator bindings. These bindings are one to one mapping to the FFI functions exposed from safe_api and safe_authenicator native libraries.
-* Native libraries generated from [safe-api](https://github.com/maidsafe/safe-api) containing required logic to connect, read and write data on the SAFE Network.
+* sn_api and mock safe_authenticator bindings. These bindings are one to one mapping to the FFI functions exposed from sn_api and safe_authenicator native libraries.
+* Native libraries generated from [sn_api](https://github.com/maidsafe/sn_api) containing required logic to connect, read and write data on the Safe Network.
 
 ## Supported Platforms
 
@@ -49,20 +53,20 @@ At a very high level, this package includes:
 
 ## API Usage
 
-To develop desktop and mobile apps for the SAFE Network install the latest [MaidSafe.SafeApp](https://www.nuget.org/packages/MaidSafe.SafeApp/) package from NuGet.
+To develop desktop and mobile apps for the Safe Network install the latest [MaidSafe.SafeApp](https://www.nuget.org/packages/MaidSafe.SafeApp/) package from NuGet.
 
 This package provides support for mock and non-mock network. By default, non-mock API are used in the package.
 
 ### Using Mock API
 
 * Mock API can be used by adding a `SAFE_APP_MOCK` flag in your project properties at **Properties > Build > conditional compilation symbols**.
-* When the mock feature is used, a local mock vault file is generated which simulates network operations used to store and retrieve data. The app will then interface with this file rather than the live SAFE network.
+* When the mock feature is used, a local mock vault file is generated which simulates network operations used to store and retrieve data. The app will then interface with this file rather than the live Safe network.
 
 ### Authentication
 
-* Applications must be authenticated via the SAFE Authenticator to work with the SAFE Network.
-* The desktop authenticator is packed and shipped with the [SAFE browser](https://github.com/maidsafe/safe_browser/releases/latest).
-* On mobile devices, use the [SAFE Authenticator](https://github.com/maidsafe/safe-authenticator-mobile/releases/latest) mobile application.
+* Applications must be authenticated via the Safe Authenticator to work with the Safe Network.
+* The desktop authenticator is packed and shipped with the [Safe browser](https://github.com/maidsafe/safe_browser/releases/latest).
+* On mobile devices, use the [Safe Authenticator](https://github.com/maidsafe/safe-authenticator-mobile/releases/latest) mobile application.
 
 ## Documentation
 
@@ -80,10 +84,10 @@ docfx .\docs\docfx.json
 
 ### Project structure
 
-* **SafeApp:** C# API for safe_api
+* **SafeApp:** C# API for sn_api
   * Fetch, Inspect, Files, Keys, Wallet, XorUrl
 * **SafeApp.AppBindings:**
-  * safe_api and safe_app IPC bindings generated from safe_api and safe_client_libs
+  * sn_api and safe_app IPC bindings generated from sn_api and safe_client_libs
   * Contains native libraries for the platform
 * **SafeApp.MockAuthBindings:**
   * Mock Safe authentication C# API
@@ -99,7 +103,7 @@ docfx .\docs\docfx.json
 
 ### Interfacing with Safe Client Libs
 
-The package uses native code written in Rust and compiled into platform specific code. Learn more about the safe_client_libs in [the SAFE client libraries wiki](https://github.com/maidsafe/safe_client_libs/wiki).
+The package uses native code written in Rust and compiled into platform specific code. Learn more about the safe_client_libs in [the Safe client libraries wiki](https://github.com/maidsafe/safe_client_libs/wiki).
 
 Instructions to update the bindings can be found in the [Update Bindings file](./UpdateBindings.md).
 
@@ -131,15 +135,15 @@ https://github.com/maidsafe/safe_app_csharp/blob/master/PackageInstructions.txt)
 
 ## Copyrights
 
-Copyrights in the SAFE Network are retained by their contributors. No copyright assignment is required to contribute to this project.
+Copyrights in the Safe Network are retained by their contributors. No copyright assignment is required to contribute to this project.
 
 ## Further Help
 
-Get your developer related questions clarified on [SAFE Dev Forum](https://forum.safedev.org/). If you're looking to share any other ideas or thoughts on the SAFE Network you can reach out on [SAFE Network Forum](https://safenetforum.org/)
+Get your developer related questions clarified on [Safe Dev Forum](https://forum.safedev.org/). If you're looking to share any other ideas or thoughts on the Safe Network you can reach out on [Safe Network Forum](https://safenetforum.org/)
 
 ## License
 
-This SAFE Network library is dual-licensed under the Modified BSD ([LICENSE-BSD](LICENSE-BSD) https://opensource.org/licenses/BSD-3-Clause) or the MIT license ([LICENSE-MIT](LICENSE-MIT) https://opensource.org/licenses/MIT) at your option.
+This Safe Network library is dual-licensed under the Modified BSD ([LICENSE-BSD](LICENSE-BSD) https://opensource.org/licenses/BSD-3-Clause) or the MIT license ([LICENSE-MIT](LICENSE-MIT) https://opensource.org/licenses/MIT) at your option.
 
 ## Contributing
 

--- a/SafeApp.AppBindings/AppBindings.cs
+++ b/SafeApp.AppBindings/AppBindings.cs
@@ -16,7 +16,7 @@ namespace SafeApp.AppBindings
         #if __IOS__
         private const string DllName = "__Internal";
         #else
-        private const string DllName = "safe_api";
+        private const string DllName = "sn_api";
         #endif
 
         #region App Level

--- a/SafeApp.AppBindings/Targets/Android.targets
+++ b/SafeApp.AppBindings/Targets/Android.targets
@@ -17,8 +17,8 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\armeabi-v7a\libsafe_api.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\x86_64\libsafe_api.so" />
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\armeabi-v7a\libsn_api.so" />
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\x86_64\libsn_api.so" />
   </ItemGroup>
   <ItemGroup Condition="$(DefineConstants.Contains(SAFE_AUTH))">
     <Reference Include="SafeAuthenticator">

--- a/SafeApp.AppBindings/Targets/NetCore.targets
+++ b/SafeApp.AppBindings/Targets/NetCore.targets
@@ -24,17 +24,17 @@
   <Choose>
     <When Condition=" '$(IsWindows)' == 'true' ">
       <PropertyGroup>
-        <NativeLibFile>safe_api.dll</NativeLibFile>
+        <NativeLibFile>sn_api.dll</NativeLibFile>
       </PropertyGroup>
     </When>
     <When Condition=" $(IsOSX)' == 'true' ">
       <PropertyGroup>
-        <NativeLibFile>libsafe_api.dylib</NativeLibFile>
+        <NativeLibFile>libsn_api.dylib</NativeLibFile>
       </PropertyGroup>
     </When>
     <When Condition="'$(IsLinux)' == 'true' ">
       <PropertyGroup>
-        <NativeLibFile>libsafe_api.so</NativeLibFile>
+        <NativeLibFile>libsn_api.so</NativeLibFile>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/SafeApp.AppBindings/Targets/iOS.targets
+++ b/SafeApp.AppBindings/Targets/iOS.targets
@@ -17,7 +17,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <NativeReference Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\libsafe_api.a">
+    <NativeReference Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\libsn_api.a">
       <Kind>Static</Kind>
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-lresolv</LinkerFlags>

--- a/SafeApp.nuspec
+++ b/SafeApp.nuspec
@@ -116,8 +116,8 @@
 
     <!--Desktop - NetFramework-->
     <file src="SafeApp.AppBindings\Targets\NetFramework.targets" target="build\net472\MaidSafe.SafeApp.targets" />
-    <file src="SafeApp.AppBindings\NativeLibs\Desktop\mock\safe_api.dll" target="build\net472\lib\mock\safe_api.dll" />
-    <file src="SafeApp.AppBindings\NativeLibs\Desktop\non-mock\safe_api.dll" target="build\net472\lib\non-mock\safe_api.dll" />
+    <file src="SafeApp.AppBindings\NativeLibs\Desktop\mock\sn_api.dll" target="build\net472\lib\mock\sn_api.dll" />
+    <file src="SafeApp.AppBindings\NativeLibs\Desktop\non-mock\sn_api.dll" target="build\net472\lib\non-mock\sn_api.dll" />
     <file src="SafeApp\bin\Release\netstandard2.0\SafeApp.dll" target="lib\net472\SafeApp.dll" />
     <file src="SafeApp\bin\Release\netstandard2.0\SafeApp.pdb" target="lib\net472\SafeApp.pdb" />
     <file src="SafeApp\bin\Release\netstandard2.0\SafeApp.xml" target="lib\net472\SafeApp.xml" />

--- a/SafeAuthenticator/AuthBindings.cs
+++ b/SafeAuthenticator/AuthBindings.cs
@@ -15,7 +15,7 @@ namespace SafeAuthenticator
 #if __IOS__
         private const string DllName = "__Internal";
 #else
-        private const string DllName = "safe_api";
+        private const string DllName = "sn_api";
 #endif
 
         public bool AuthIsMock()

--- a/Tests/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
+++ b/Tests/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
@@ -60,11 +60,11 @@
     <Compile Include="Resources\Resource.Designer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidNativeLibrary Include="..\..\SafeApp.AppBindings\NativeLibs\Android\mock\armeabi-v7a\libsafe_api.so">
-      <Link>lib\armeabi-v7a\libsafe_api.so</Link>
+    <AndroidNativeLibrary Include="..\..\SafeApp.AppBindings\NativeLibs\Android\mock\armeabi-v7a\libsn_api.so">
+      <Link>lib\armeabi-v7a\libsn_api.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="..\..\SafeApp.AppBindings\NativeLibs\Android\mock\x86_64\libsafe_api.so">
-      <Link>lib\x86_64\libsafe_api.so</Link>
+    <AndroidNativeLibrary Include="..\..\SafeApp.AppBindings\NativeLibs\Android\mock\x86_64\libsn_api.so">
+      <Link>lib\x86_64\libsn_api.so</Link>
     </AndroidNativeLibrary>
     <AndroidAsset Include="..\SafeApp.Tests\log.toml">
       <Link>Assets\log.toml</Link>

--- a/Tests/SafeApp.Tests.Core/SafeApp.Tests.Core.csproj
+++ b/Tests/SafeApp.Tests.Core/SafeApp.Tests.Core.csproj
@@ -32,13 +32,13 @@
   </Choose>
 
   <ItemGroup>
-    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\$(NativeLibType)\libsafe_api.dylib" Link="libsafe_api.dylib" Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">
+    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\$(NativeLibType)\libsn_api.dylib" Link="libsn_api.dylib" Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\$(NativeLibType)\libsafe_api.so" Link="libsafe_api.so" Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">
+    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\$(NativeLibType)\libsn_api.so" Link="libsn_api.so" Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\$(NativeLibType)\safe_api.dll" Link="safe_api.dll" Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
+    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\$(NativeLibType)\sn_api.dll" Link="sn_api.dll" Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="..\SafeApp.Tests\log.toml" Link="log.toml">

--- a/Tests/SafeApp.Tests.Framework/SafeApp.Tests.Framework.csproj
+++ b/Tests/SafeApp.Tests.Framework/SafeApp.Tests.Framework.csproj
@@ -83,8 +83,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\safe_api.dll">
-      <Link>safe_api.dll</Link>
+    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\sn_api.dll">
+      <Link>sn_api.dll</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Tests/SafeApp.Tests.iOS/SafeApp.Tests.iOS.csproj
+++ b/Tests/SafeApp.Tests.iOS/SafeApp.Tests.iOS.csproj
@@ -127,7 +127,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\SafeApp.AppBindings\NativeLibs\iOS\mock\libsafe_api.a">
+    <NativeReference Include="..\..\SafeApp.AppBindings\NativeLibs\iOS\mock\libsn_api.a">
       <Kind>Static</Kind>
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-lresolv</LinkerFlags>

--- a/Tests/SafeApp.Tests/log.toml
+++ b/Tests/SafeApp.Tests/log.toml
@@ -32,8 +32,8 @@ level = "trace"
 [loggers."sn_ffi_utils"]
 level = "trace"
 
-[loggers."safe_api"]
+[loggers."sn_api"]
 level = "debug"
 
-[loggers."safe_ffi"]
+[loggers."sn_ffi"]
 level = "debug"

--- a/UpdateBindings.md
+++ b/UpdateBindings.md
@@ -1,13 +1,13 @@
-# Updating safe_app_csharp bindings from safe_ffi
+# Updating safe_app_csharp bindings from sn_ffi
 
 * Updating `safe_app` bindings in `safe_app_csharp`
-  * Generate bindings for `safe-ffi`.
-  * Update bindings in `SafeApp.AppBindings` project with new generated `safe-ffi` bindings.
+  * Generate bindings for `sn_ffi`.
+  * Update bindings in `SafeApp.AppBindings` project with new generated `sn_ffi` bindings.
   * Update manual files in `SafeApp.AppBindings` project.
   * Update core files in `SafeApp.Core` project.
 * Updating `safe_authenticator` bindings in `safe_app_csharp`
-  * Generate bindings for `safe-ffi`.
-  * Update bindings in `SafeAuthenticator/AuthBindings.cs` file with new generated `safe-ffi` bindings.
+  * Generate bindings for `sn_ffi`.
+  * Update bindings in `SafeAuthenticator/AuthBindings.cs` file with new generated `sn_ffi` bindings.
   * Update manual files in `SafeAuthenticator` project.
 
-***Note:** Make sure the changes made in the manual files in `safe_app_csharp` are synced with `safe-ffi` and vice versa.*
+***Note:** Make sure the changes made in the manual files in `safe_app_csharp` are synced with `sn_ffi` and vice versa.*


### PR DESCRIPTION
Also includes renaming `SAFE` to `Safe` in the readme.

It is expected that CI will fail on this PR, and any others after it is merged, until a new version of the sn_api, sn_cli & sn_ffi are released with the new naming conventions --> https://dev.azure.com/maidsafe/SafeApp/_build/results?buildId=1913&view=logs&j=b5c3680a-75af-5c19-dc38-e2ccb7d74d37&t=a1fe8770-d8e3-5fd2-7165-f056bd7cb277&l=266